### PR TITLE
Fixed validation of dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.2] - 2018-04-21
+### Fixed
+ - Validation of dates
+
 ## [2.1.1] - 2018-04-20
 ### Fixed
  - Forced choice value to be string when marking selected

--- a/src/Fields/TemporalField.php
+++ b/src/Fields/TemporalField.php
@@ -18,6 +18,11 @@ class TemporalField extends Field
         parent::__construct($args);
     }
 
+    public function isValidDate($date_original, $date_created)
+    {
+        return $date_created && $date_created->format($this->format) == '!' . $date_original;
+    }
+
     public function toNative($value)
     {
         if (empty($value)) {
@@ -26,7 +31,7 @@ class TemporalField extends Field
 
         $date = date_create_from_format($this->format, $value);
 
-        if (!$date) {
+        if (!$date || !$this->isValidDate($value, $date)) {
             throw new ValidationError($this->error_messages['invalid'], 'invalid');
         }
 


### PR DESCRIPTION
When using dates like '31-02-2015' it would accept it and return the date of '03-03-2015' that is wrong.

Added validation to make sure the resulted date object is the same of the input, otherwise throws ValidationError